### PR TITLE
Byte stream

### DIFF
--- a/pkg/io/bytestream.go
+++ b/pkg/io/bytestream.go
@@ -51,5 +51,10 @@ func (b *ByteStream) Stream() <-chan []byte {
 		return b.channel
 	}
 
+	go func ()  {
+		var nextByte int64
+		readBuffer := make([]byte, b.maxReadSize)
+	}
+
 	return b.channel
 }

--- a/pkg/io/bytestream.go
+++ b/pkg/io/bytestream.go
@@ -1,0 +1,28 @@
+package io
+
+// DefaultMaxBufferSize is the default maximum number of bytes that a ByteStream
+// will read from the underlying buffer at once.
+const DefaultMaxBufferSize = 1024
+
+// ByteStream enables clients to stream bytes from an OutputBuffer.
+type ByteStream struct {
+	buffer      OutputBuffer
+	channel     chan []byte
+	maxReadSize int
+}
+
+// NewByteStream creates and returns a new ByteStream associated with the
+// given buffer with a read buffer size of DefaultMaxBufferSize.
+func NewByteStream(buffer OutputBuffer) *ByteStream {
+	return NewByteStreamDetailed(buffer, DefaultMaxBufferSize)
+}
+
+// NewByteStream creates and returns a new ByteStream associated with the
+// given buffer with a read buffer size of the given maxReadSize.
+func NewByteStreamDetailed(buffer OutputBuffer, maxReadSize int) *ByteStream {
+	return &ByteStream{
+		channel:     make(chan []byte),
+		buffer:      buffer,
+		maxReadSize: maxReadSize,
+	}
+}

--- a/pkg/io/bytestream.go
+++ b/pkg/io/bytestream.go
@@ -1,9 +1,12 @@
 package io
 
-import "sync"
+import (
+	"log"
+	"sync"
+)
 
 // DefaultMaxBufferSize is the default maximum number of bytes that a ByteStream
-// will read from the underlying buffer at once.
+// will read from the underlying buffer at at once.
 const DefaultMaxBufferSize = 1024
 
 // ByteStream enables clients to stream bytes from an OutputBuffer.
@@ -35,6 +38,7 @@ func NewByteStreamDetailed(buffer OutputBuffer, maxReadSize int) *ByteStream {
 
 // Stream returns a chanel that streams the content of the underlying OutputBuffer.
 func (b *ByteStream) Stream() <-chan []byte {
+
 	bailEarly := true
 
 	func() {
@@ -47,14 +51,52 @@ func (b *ByteStream) Stream() <-chan []byte {
 		}
 	}()
 
+	// If some other call to Stream has already created the goroutine, then
+	// there's nothing for this call to do other than to return the channel.
 	if bailEarly {
 		return b.channel
 	}
 
-	go func ()  {
+	go func() {
 		var nextByte int64
 		readBuffer := make([]byte, b.maxReadSize)
-	}
+
+		for {
+			bufferSize, _ := b.buffer.waitForChange(nextByte)
+
+			// At this point the underlying buffer could be closed, there could
+			// be new bytes in the buffer to process, or both.
+
+			if bufferSize == nextByte {
+				// No new bytes to process; the buffer must be closed and this
+				// streamer must have consumed all the bytes that were written
+				// to the buffer. Terminate the goroutine.
+				close(b.channel)
+				return
+			}
+
+			if n, err := b.buffer.ReadAt(readBuffer, nextByte); err != nil {
+				// If ReadAt fails, we'l assume the buffer is in a bad state
+				// and that future reads would also fail.
+
+				log.Printf("Unexpected failure reading from underlying buffer: %v", err)
+
+				close(b.channel)
+				return
+			} else if n > 0 {
+				// Create a copy here because we're reusing readBuffer here.
+				bufToWrite := make([]byte, n)
+				copy(bufToWrite, readBuffer[0:n])
+
+				b.channel <- bufToWrite
+				nextByte += int64(n)
+			}
+
+			// If n == 0, then it's possible that new bytes were written to the
+			// buffer since we inspected its size above.  In that case, we'll
+			// get the updated size and reevaluate on the next iteration.
+		}
+	}()
 
 	return b.channel
 }

--- a/pkg/io/bytestream_test.go
+++ b/pkg/io/bytestream_test.go
@@ -1,0 +1,95 @@
+package io_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/io"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ByteStream(t *testing.T) {
+	const iterationCount = 5
+	payload := []byte("hello")
+	output := make([]byte, 0, iterationCount*len(payload))
+
+	buffer := io.NewMemoryBuffer()
+	stream := io.NewByteStream(buffer)
+
+	byteCount := 0
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for content := range stream.Stream() {
+			byteCount += len(content)
+			output = append(output, content...)
+		}
+		wg.Done()
+	}()
+
+	for i := 0; i < iterationCount; i++ {
+		buffer.Write(payload)
+	}
+
+	buffer.Close()
+	wg.Wait()
+
+	assert.Equal(t, iterationCount*len(payload), byteCount)
+	assert.Equal(t, []byte("hellohellohellohellohello"), output)
+}
+
+func Test_ByteStream_MultipleCallsToStream(t *testing.T) {
+	buffer := io.NewMemoryBuffer()
+	stream := io.NewByteStream(buffer)
+
+	buffer.Write([]byte("hello"))
+	assert.Equal(t, []byte("hello"), <-stream.Stream())
+
+	buffer.Write([]byte("world"))
+	assert.Equal(t, []byte("world"), <-stream.Stream())
+
+	buffer.Close()
+	assert.Nil(t, <-stream.Stream())
+}
+
+func Test_ByteStream_MultipleReaders(t *testing.T) {
+	buffer := io.NewMemoryBuffer()
+	stream1 := io.NewByteStream(buffer).Stream()
+	stream2 := io.NewByteStream(buffer).Stream()
+
+	buffer.Write([]byte("hello"))
+	assert.Equal(t, []byte("hello"), <-stream1)
+	assert.Equal(t, []byte("hello"), <-stream2)
+
+	buffer.Write([]byte("world"))
+	assert.Equal(t, []byte("world"), <-stream1)
+	assert.Equal(t, []byte("world"), <-stream2)
+
+	buffer.Close()
+	assert.Nil(t, <-stream1)
+	assert.Nil(t, <-stream2)
+}
+
+/*
+
+func Test_ByteStream_Stream(t *testing.T) {
+	buffer := io.NewMemoryBuffer()
+	stream := io.NewByteStream(buffer)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < 100; j++ {
+				stream.Stream()
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+*/

--- a/pkg/io/outputbuffer.go
+++ b/pkg/io/outputbuffer.go
@@ -10,4 +10,6 @@ type OutputBuffer interface {
 	goio.Writer
 	goio.ReaderAt
 	goio.Closer
+
+	waitForChange(nextByte int64) (bufferSize int64, closed bool)
 }

--- a/pkg/io/outputbuffer.go
+++ b/pkg/io/outputbuffer.go
@@ -1,0 +1,13 @@
+package io
+
+import (
+	goio "io"
+)
+
+// OutputBuffer is an abstraction over buffers to which the job manager
+// can write output.
+type OutputBuffer interface {
+	goio.Writer
+	goio.ReaderAt
+	goio.Closer
+}


### PR DESCRIPTION
This change introduces the ByteStream component and associated unit
tests.  It updates the MemoryBuffer component to enable the ByteStream
component to block waiting for changes.

This also introduces a new interface -- OutputBuffer.  This is used to
decouple the ByteStream from the concrete OutputBuffer.  That way, if at
some time in the future we wanted to support writing to something else
(e.g., a file), we could reuse the ByteStream component without
modification.