### PR TITLE
Cgroup management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/obaraelijah/teleport-challenge
 
 go 1.22.0
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.9.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/pkg/cgroup/v1/base.go
+++ b/pkg/cgroup/v1/base.go
@@ -1,0 +1,33 @@
+package cgroup
+
+import (
+	"fmt"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+)
+
+const DefaultFileMode os.FileMode = 0644
+
+// base is the base type for all cgroup controllers
+type base struct {
+	osAdapter *os.Adapter
+	// name is the controller name
+	name string
+}
+
+func newBase(name string, osAdapter *os.Adapter) base {
+	return base{
+		osAdapter: osAdapter,
+		name:      name,
+	}
+}
+
+// Name returns the name of this cgroup controller
+func (b *base) Name() string {
+	return b.name
+}
+
+// write update the cgroup file constructed with the given pathFmt and args with the given value.
+func (b *base) write(value []byte, pathFmt string, args ...interface{}) error {
+	return b.osAdapter.WriteFile(fmt.Sprintf(pathFmt, args...), value, DefaultFileMode)
+}

--- a/pkg/cgroup/v1/blockio.go
+++ b/pkg/cgroup/v1/blockio.go
@@ -1,0 +1,54 @@
+package cgroup
+
+import "github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+
+const (
+	BlkioThrottleReadBpsDevice  = "blkio.throttle.read_bps_device"
+	BlkioThrottleWriteBpsDevice = "blkio.throttle.write_bps_device"
+)
+
+type blockIo struct {
+	base
+	readBpsDevice  *string
+	writeBpsDevice *string
+}
+
+func NewBlockIoController() *blockIo {
+	return NewBlockIoControllerDetailed(nil)
+}
+
+func NewBlockIoControllerDetailed(osAdapter *os.Adapter) *blockIo {
+	return &blockIo{
+		base: newBase("blkio", osAdapter),
+	}
+}
+
+func (b *blockIo) Apply(path string) error {
+	if b.readBpsDevice != nil {
+		if err := b.write([]byte(*b.readBpsDevice), "%s/%s", path, BlkioThrottleReadBpsDevice); err != nil {
+			return err
+		}
+	}
+
+	if b.writeBpsDevice != nil {
+		if err := b.write([]byte(*b.writeBpsDevice), "%s/%s", path, BlkioThrottleWriteBpsDevice); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Fluent interface for setting read limit
+func (b *blockIo) SetReadBpsDevice(value string) *blockIo {
+	b.readBpsDevice = &value
+
+	return b
+}
+
+// Fluent interface for setting write limit
+func (b *blockIo) SetWriteBpsDevice(value string) *blockIo {
+	b.writeBpsDevice = &value
+
+	return b
+}

--- a/pkg/cgroup/v1/blockio_test.go
+++ b/pkg/cgroup/v1/blockio_test.go
@@ -1,0 +1,30 @@
+package cgroup_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os/ostest"
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_blkio_Apply(t *testing.T) {
+	path := "/sys/fs/cgroup/jobs/889f7cc2-9935-4773-aaa1-b94478abc923"
+	writeRecorder := ostest.WriteFileRecorder{}
+	adapter := &os.Adapter{
+		WriteFileFn: writeRecorder.WriteFile,
+	}
+	readBps := "1:2 1G"
+	writeBps := "1:3 900M"
+	blkio := cgroup.NewBlockIoControllerDetailed(adapter).
+		SetReadBpsDevice(readBps).
+		SetWriteBpsDevice(writeBps)
+	blkio.Apply(path)
+	assert.Equal(t, 2, len(writeRecorder.Events))
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.BlkioThrottleReadBpsDevice), writeRecorder.Events[0].Name)
+	assert.Equal(t, []byte(readBps), writeRecorder.Events[0].Data)
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.BlkioThrottleWriteBpsDevice), writeRecorder.Events[1].Name)
+	assert.Equal(t, []byte(writeBps), writeRecorder.Events[1].Data)
+}

--- a/pkg/cgroup/v1/cgrouptest/dummyController.go
+++ b/pkg/cgroup/v1/cgrouptest/dummyController.go
@@ -1,0 +1,19 @@
+package cgrouptest
+
+type Controller interface {
+	Name() string
+	Apply(path string) error
+}
+
+type DummyController struct {
+	ControllerName   string
+	ApplyReturnValue error
+}
+
+func (d *DummyController) Name() string {
+	return d.ControllerName
+}
+
+func (d *DummyController) Apply(string) error {
+	return d.ApplyReturnValue
+}

--- a/pkg/cgroup/v1/controller.go
+++ b/pkg/cgroup/v1/controller.go
@@ -1,0 +1,6 @@
+package cgroup
+
+type Controller interface {
+	Name() string
+	Apply(path string) error
+}

--- a/pkg/cgroup/v1/cpu.go
+++ b/pkg/cgroup/v1/cpu.go
@@ -1,0 +1,57 @@
+package cgroup
+
+import (
+	"fmt"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+)
+
+const (
+	CpuPeriodFilename = "cpu.cfs_period_us"
+	CpuQuotaFilename  = "cpu.cfs_quota_us"
+
+	defaultPeriodUs = 100000
+)
+
+var defaultPeriodBytes = []byte(fmt.Sprintf("%d", defaultPeriodUs))
+
+// cpu implements cgroup v2 control using CFS Bandwidth Control.
+// See doc/Documentation/scheduler/sched-bwc.txt in the kernel source tree for
+// additional information.
+//
+// This implementation exposes that functionality in terms of how much of the
+// available CPU resources a collection of processes can use (0.5 = half a CPU,
+// 1.0 = 1 CPU, 1.5 = 1 and a half CPUs, ...).
+// The period is defaultPeriodUs and the quota is cpus*period.
+type cpu struct {
+	base
+	cpus *float64
+}
+
+func NewCpuController() *cpu {
+	return NewCpuControllerDetailed(nil)
+}
+
+func NewCpuControllerDetailed(osAdapter *os.Adapter) *cpu {
+	return &cpu{
+		base: newBase("cpu", osAdapter),
+	}
+}
+
+func (c *cpu) SetCpus(value float64) *cpu {
+	c.cpus = &value
+	return c
+}
+
+func (c *cpu) Apply(path string) error {
+	if c.cpus != nil {
+		if err := c.write(defaultPeriodBytes, "%s/%s", path, CpuPeriodFilename); err != nil {
+			return err
+		}
+		quota := fmt.Sprintf("%d", int(*c.cpus*defaultPeriodUs))
+		if err := c.write([]byte(quota), "%s/%s", path, CpuQuotaFilename); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cgroup/v1/cpu_test.go
+++ b/pkg/cgroup/v1/cpu_test.go
@@ -1,0 +1,26 @@
+package cgroup_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os/ostest"
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cpu_Apply(t *testing.T) {
+	path := "/sys/fs/cgroup/jobs/889f7cc2-9935-4773-aaa1-b94478abc923"
+	writeRecorder := ostest.WriteFileRecorder{}
+	adapter := &os.Adapter{
+		WriteFileFn: writeRecorder.WriteFile,
+	}
+	cpu := cgroup.NewCpuControllerDetailed(adapter).SetCpus(2.0)
+	cpu.Apply(path)
+	assert.Equal(t, 2, len(writeRecorder.Events))
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.CpuPeriodFilename), writeRecorder.Events[0].Name)
+	assert.Equal(t, []byte("100000"), writeRecorder.Events[0].Data)
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.CpuQuotaFilename), writeRecorder.Events[1].Name)
+	assert.Equal(t, []byte("200000"), writeRecorder.Events[1].Data)
+}

--- a/pkg/cgroup/v1/doc.go
+++ b/pkg/cgroup/v1/doc.go
@@ -1,0 +1,9 @@
+// Package cgroup provides an simple abstraction over the cgroup v1 interface.
+// The rationale to implement was driven by the fact that on my system, both
+// the v1 and v2 interfaces are mounted and the v1 interface is in use.
+//
+// I've versioned the package structure so that we could easily build a v2
+// implementation.  We could also add some code to the parent package to
+// enable us to examine the system and automatically pick the most suitable
+// implementation.
+package cgroup

--- a/pkg/cgroup/v1/memory.go
+++ b/pkg/cgroup/v1/memory.go
@@ -1,0 +1,35 @@
+package cgroup
+
+import "github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+
+const (
+	MemoryLimitInBytesFilename = "memory.limit_in_bytes"
+)
+
+// memory configures the memory cgroup controller.
+type memory struct {
+	base
+	limit *string
+}
+
+func NewMemoryDetailed(osAdapter *os.Adapter) *memory {
+	return &memory{
+		base: newBase("memory", osAdapter),
+	}
+}
+
+func (m *memory) SetLimit(value string) *memory {
+	m.limit = &value
+
+	return m
+}
+
+func (m *memory) Apply(path string) error {
+	if m.limit != nil {
+		if err := m.write([]byte(*m.limit), "%s/%s", path, MemoryLimitInBytesFilename); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cgroup/v1/memory_test.go
+++ b/pkg/cgroup/v1/memory_test.go
@@ -1,0 +1,25 @@
+package cgroup_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os/ostest"
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_memory_Apply(t *testing.T) {
+	path := "/sys/fs/cgroup/jobs/889f7cc2-9935-4773-aaa1-b94478abc923"
+	writeRecorder := ostest.WriteFileRecorder{}
+	adapter := &os.Adapter{
+		WriteFileFn: writeRecorder.WriteFile,
+	}
+	limit := "500M"
+	mem := cgroup.NewMemoryDetailed(adapter).SetLimit(limit)
+	mem.Apply(path)
+	assert.Equal(t, 1, len(writeRecorder.Events))
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.MemoryLimitInBytesFilename), writeRecorder.Events[0].Name)
+	assert.Equal(t, []byte(limit), writeRecorder.Events[0].Data)
+}

--- a/pkg/cgroup/v1/set.go
+++ b/pkg/cgroup/v1/set.go
@@ -1,0 +1,127 @@
+package cgroup
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+)
+
+const (
+	DefaultBasePath                   = "/sys/fs/cgroup"
+	defaultDirectoryPerms os.FileMode = 0755
+)
+
+type Set struct {
+	osAdapter   *os.Adapter
+	basePath    string
+	jobId       uuid.UUID
+	controllers []Controller
+}
+
+// NewSet creates a new cgroup (v1) set for the given jobID.  This assumes that
+// the cgroup filesystem is mounted at /sys/fs/cgroup.
+func NewSet(jobId uuid.UUID, controllers ...Controller) *Set {
+	return NewSetDetailed(nil, DefaultBasePath, jobId, controllers...)
+}
+
+// NewSetDetailed creates a new cgroup (v1) set for the given jobID rooted
+// at the given basePath.
+func NewSetDetailed(
+	osAdapter *os.Adapter,
+	basePath string,
+	jobId uuid.UUID,
+	controllers ...Controller,
+) *Set {
+
+	return &Set{
+		osAdapter:   osAdapter,
+		basePath:    basePath,
+		jobId:       jobId,
+		controllers: controllers,
+	}
+}
+
+// Create creates the cgroup v1 directories for all registered controllers.
+func (s *Set) Create() (retErr error) {
+	if s == nil {
+		// If the set is nil, then Create is vacuously successful
+		return nil
+	}
+
+	failPoint := -1
+
+	for i := range s.controllers {
+		path := fmt.Sprintf("%s/%s/jobs/%s", s.basePath, s.controllers[i].Name(), s.jobId.String())
+
+		// Create the cgroup
+		if err := s.osAdapter.MkdirAll(path, defaultDirectoryPerms); err != nil {
+			retErr = err
+			failPoint = i
+			break
+		}
+
+		// Apply the supplied configuration to the newly-created cgroup
+		if err := s.controllers[i].Apply(path); err != nil {
+			retErr = err
+			failPoint = i
+			break
+		}
+	}
+
+	for i := failPoint; i >= 0; i-- {
+		path := fmt.Sprintf("%s/%s/jobs/%s", s.basePath, s.controllers[i].Name(), s.jobId.String())
+
+		if err := s.osAdapter.Remove(path); err != nil {
+			_ = err
+			log.Printf("Failed to backout cgroup %s: %v", s.controllers[i].Name(), err)
+			// Intentionally not returning an error here
+		}
+	}
+
+	return
+}
+
+// Destroy removes the cgroup v1 directories for all registered controllers.
+func (s *Set) Destroy() error {
+	if s == nil {
+		// If the set is nil, then Delete is vacuously successful
+		return nil
+	}
+
+	var failedCgroups []string
+
+	for i := len(s.controllers) - 1; i >= 0; i-- {
+		path := fmt.Sprintf("%s/%s/jobs/%s", s.basePath, s.controllers[i].Name(), s.jobId.String())
+
+		if err := s.osAdapter.Remove(path); err != nil {
+			failedCgroups = append(failedCgroups, path)
+		}
+	}
+
+	if len(failedCgroups) > 0 {
+		return fmt.Errorf("failed to destroy cgroups: %s", strings.Join(failedCgroups, ", "))
+	}
+
+	return nil
+}
+
+func (s *Set) TaskFiles() []string {
+	if s == nil {
+		return nil
+	}
+
+	taskFiles := make([]string, 0, len(s.controllers))
+
+	for i := range s.controllers {
+		taskFiles = append(taskFiles, fmt.Sprintf(
+			"%s/%s/jobs/%s/tasks",
+			s.basePath,
+			s.controllers[i].Name(),
+			s.jobId.String()))
+	}
+
+	return taskFiles
+}

--- a/pkg/cgroup/v1/set_test.go
+++ b/pkg/cgroup/v1/set_test.go
@@ -1,0 +1,132 @@
+package cgroup_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os"
+	"github.com/obaraelijah/teleport-challenge/pkg/adaptation/os/ostest"
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1"
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1/cgrouptest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Set_Create_Success(t *testing.T) {
+	jobId, _ := uuid.Parse("0b5183b8-b572-49c7-90c4-fffc775b7d7b")
+	mkdirAllRecorder := ostest.MkdirAllRecorder{}
+	removeRecorder := ostest.RemoveRecorder{}
+
+	adapter := &os.Adapter{
+		MkdirAllFn: mkdirAllRecorder.MkdirAll,
+		RemoveFn:   removeRecorder.Remove,
+	}
+
+	controller := &cgrouptest.DummyController{ControllerName: "nil"}
+	set := cgroup.NewSetDetailed(adapter, cgroup.DefaultBasePath, jobId, controller)
+
+	err := set.Create()
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mkdirAllRecorder.Events))
+	assert.Equal(t, 0, len(removeRecorder.Events))
+	assert.Equal(t,
+		fmt.Sprintf("%s/%s/jobs/%s",
+			cgroup.DefaultBasePath,
+			controller.Name(),
+			jobId.String(),
+		),
+		mkdirAllRecorder.Events[0].Path)
+}
+
+func Test_Set_Create_Failure(t *testing.T) {
+	jobId, _ := uuid.Parse("0b5183b8-b572-49c7-90c4-fffc775b7d7b")
+	mkdirAllRecorder := ostest.MkdirAllRecorder{}
+	removeRecorder := ostest.RemoveRecorder{}
+
+	adapter := &os.Adapter{
+		MkdirAllFn: mkdirAllRecorder.MkdirAll,
+		RemoveFn:   removeRecorder.Remove,
+	}
+
+	expectedError := fmt.Errorf("injected error")
+	controller := &cgrouptest.DummyController{
+		ControllerName:   "nil",
+		ApplyReturnValue: expectedError,
+	}
+	set := cgroup.NewSetDetailed(adapter, cgroup.DefaultBasePath, jobId, controller)
+
+	err := set.Create()
+
+	assert.Equal(t, expectedError, err)
+	assert.Equal(t, 1, len(removeRecorder.Events))
+	assert.Equal(t,
+		fmt.Sprintf("%s/%s/jobs/%s",
+			cgroup.DefaultBasePath,
+			controller.Name(),
+			jobId.String(),
+		),
+		removeRecorder.Events[0].Path)
+}
+
+func Test_Set_Destroy_Success(t *testing.T) {
+	jobId, _ := uuid.Parse("0b5183b8-b572-49c7-90c4-fffc775b7d7b")
+	removeRecorder := ostest.RemoveRecorder{}
+
+	adapter := &os.Adapter{
+		RemoveFn: removeRecorder.Remove,
+	}
+
+	controller := &cgrouptest.DummyController{ControllerName: "nil"}
+	set := cgroup.NewSetDetailed(adapter, cgroup.DefaultBasePath, jobId, controller)
+
+	err := set.Destroy()
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(removeRecorder.Events))
+	assert.Equal(t,
+		fmt.Sprintf("%s/%s/jobs/%s",
+			cgroup.DefaultBasePath,
+			controller.Name(),
+			jobId.String(),
+		),
+		removeRecorder.Events[0].Path)
+}
+
+func Test_Set_Destroy_Failure(t *testing.T) {
+	jobId, _ := uuid.Parse("0b5183b8-b572-49c7-90c4-fffc775b7d7b")
+	injectedError := fmt.Errorf("injected error")
+	removeRecorder := ostest.RemoveRecorder{
+		NextError: injectedError,
+	}
+
+	adapter := &os.Adapter{
+		RemoveFn: removeRecorder.Remove,
+	}
+
+	controller := &cgrouptest.DummyController{ControllerName: "nil"}
+	set := cgroup.NewSetDetailed(adapter, cgroup.DefaultBasePath, jobId, controller)
+
+	err := set.Destroy()
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, len(removeRecorder.Events))
+}
+
+func Test_Set_TaskFiles(t *testing.T) {
+	jobId, _ := uuid.Parse("0b5183b8-b572-49c7-90c4-fffc775b7d7b")
+
+	controller := &cgrouptest.DummyController{ControllerName: "nil"}
+	set := cgroup.NewSet(jobId, controller)
+
+	taskFiles := set.TaskFiles()
+
+	assert.Equal(t, 1, len(taskFiles))
+	assert.Equal(t,
+		fmt.Sprintf("%s/%s/jobs/%s/tasks",
+			cgroup.DefaultBasePath,
+			controller.Name(),
+			jobId.String(),
+		),
+		taskFiles[0])
+}


### PR DESCRIPTION
This change introduces the cgroup management API.  In includes the Set
along with the cpu, memory, and blkio controllers.  It also includes a
dummy controller implementation for unit testing.