### PR TITLE
Jobmanager implementation

### DIFF
--- a/pkg/jobmanager/jobmanagertest/mockjob.go
+++ b/pkg/jobmanager/jobmanagertest/mockjob.go
@@ -1,0 +1,79 @@
+package jobmanagertest
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1"
+	"github.com/obaraelijah/teleport-challenge/pkg/io"
+	"github.com/obaraelijah/teleport-challenge/pkg/jobmanager"
+)
+
+type mockJob struct {
+	name    string
+	id      uuid.UUID
+	running bool
+	stdout  io.OutputBuffer
+	stderr  io.OutputBuffer
+}
+
+func NewMockJob(
+	jobName string, controllers []cgroup.Controller,
+	programPath string,
+	arguments ...string,
+) jobmanager.Job {
+	return &mockJob{
+		name:   jobName,
+		id:     uuid.New(),
+		stdout: io.NewMemoryBuffer(),
+		stderr: io.NewMemoryBuffer(),
+	}
+}
+
+func (m *mockJob) Start() error {
+
+	if m.running {
+		return fmt.Errorf("job %s (%v) has already been started", m.name, m.id)
+	}
+
+	m.running = true
+	_, _ = m.stdout.Write([]byte("this is standard output"))
+	_, _ = m.stderr.Write([]byte("this is standard error"))
+
+	return nil
+}
+
+func (m *mockJob) Stop() error {
+	m.running = false
+	m.stdout.Close()
+	m.stderr.Close()
+	return nil
+}
+
+func (m *mockJob) StdoutStream() *io.ByteStream {
+	return io.NewByteStream(m.stdout)
+}
+
+func (m *mockJob) StderrStream() *io.ByteStream {
+	return io.NewByteStream(m.stderr)
+}
+
+func (m *mockJob) Status() *jobmanager.JobStatus {
+	exitCode := -1
+
+	if m.running {
+		exitCode = 0
+	}
+
+	return &jobmanager.JobStatus{
+		Name:     m.name,
+		Id:       m.id.String(),
+		Running:  m.running,
+		Pid:      1234,
+		ExitCode: exitCode,
+	}
+}
+
+func (m *mockJob) Id() uuid.UUID {
+	return m.id
+}

--- a/pkg/jobmanager/manager.go
+++ b/pkg/jobmanager/manager.go
@@ -1,0 +1,48 @@
+package jobmanager
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/cgroup/v1"
+)
+
+type JobConstructor func(
+	jobName string,
+	controllers []cgroup.Controller,
+	programPath string,
+	arguments ...string,
+) Job
+
+type Manager struct {
+	mutex          sync.RWMutex
+	jobsByUser     map[string]map[string]Job // userId->jobId->job
+	allJobs        map[string]Job            // jobId->job
+	controllers    []cgroup.Controller
+	jobConstructor JobConstructor
+}
+
+func NewManager() *Manager {
+	// TODO:
+	readLimit := fmt.Sprintf("8:16 %d", 1024*1024*20)
+	writeLimit := fmt.Sprintf("8:16 %d", 1024*1024*40)
+
+	controllers := []cgroup.Controller{
+		cgroup.NewCpuController().SetCpus(0.5),
+		cgroup.NewMemoryController().SetLimit("2M"),
+		cgroup.NewBlockIoController().
+			SetReadBpsDevice(readLimit).
+			SetWriteBpsDevice(writeLimit),
+	}
+
+	return NewManagerDetailed(NewJob, controllers)
+}
+
+func NewManagerDetailed(jobConstructor JobConstructor, controllers []cgroup.Controller) *Manager {
+	return &Manager{
+		jobsByUser:     make(map[string]map[string]Job),
+		allJobs:        make(map[string]Job),
+		controllers:    controllers,
+		jobConstructor: jobConstructor,
+	}
+}

--- a/pkg/jobmanager/manager_test.go
+++ b/pkg/jobmanager/manager_test.go
@@ -1,0 +1,265 @@
+package jobmanager_test
+
+import (
+	"testing"
+
+	"github.com/obaraelijah/teleport-challenge/pkg/jobmanager"
+	"github.com/obaraelijah/teleport-challenge/pkg/jobmanager/jobmanagertest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_JobManager_Start(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, err := jm.Start(userName1, jobName, programPath, nil)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, job)
+}
+
+func Test_JobManager_Status_MatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	status, err := jm.Status(userName1, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, true, status.Running)
+	assert.Equal(t, jobName, status.Name)
+}
+
+func Test_JobManager_Status_NonMatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_, err := jm.Status("someOtherUser", job.Id().String())
+
+	assert.Error(t, err)
+}
+
+func Test_JobManager_Status_Superuser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	status, err := jm.Status(jobmanager.Superuser, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, true, status.Running)
+	assert.Equal(t, jobName, status.Name)
+}
+
+func Test_JobManager_Stop_MatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = jm.Stop(userName1, job.Id().String())
+	status, err := jm.Status(userName1, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, false, status.Running)
+	assert.Equal(t, jobName, status.Name)
+}
+
+func Test_JobManager_Stop_NonmatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	err := jm.Stop("someOtherUser", job.Id().String())
+
+	assert.Error(t, err)
+}
+func Test_JobManager_Stop_Superuser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = jm.Stop(jobmanager.Superuser, job.Id().String())
+
+	status, err := jm.Status(userName1, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, false, status.Running)
+	assert.Equal(t, jobName, status.Name)
+}
+
+func Test_JobManager_List_MatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const userName2 = "user2"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	_, _ = jm.Start(userName1, jobName, programPath, nil)
+	_, _ = jm.Start(userName2, jobName, programPath, nil)
+	jobList := jm.List(userName1)
+
+	assert.Equal(t, 1, len(jobList))
+	assert.Equal(t, true, jobList[0].Running)
+	assert.Equal(t, jobName, jobList[0].Name)
+}
+
+func Test_JobManager_List_NonmatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	_, _ = jm.Start(userName1, jobName, programPath, nil)
+	jobList := jm.List("someOtherUser")
+
+	assert.Equal(t, 0, len(jobList))
+}
+
+func Test_JobManager_List_Superuser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	_, _ = jm.Start(userName1, jobName, programPath, nil)
+	jobList := jm.List(jobmanager.Superuser)
+
+	assert.Equal(t, 1, len(jobList))
+	assert.Equal(t, true, jobList[0].Running)
+	assert.Equal(t, jobName, jobList[0].Name)
+}
+
+func Test_JobManager_List_Superuser_MultipleUsersJobs(t *testing.T) {
+	const userName1 = "user1"
+	const userName2 = "user2"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	_, _ = jm.Start(userName1, jobName, programPath, nil)
+	_, _ = jm.Start(userName2, jobName, programPath, nil)
+
+	jobList := jm.List(jobmanager.Superuser)
+
+	assert.Equal(t, 2, len(jobList))
+}
+
+func Test_JobManager_StdoutStream_MatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = job.Stop()
+
+	stream, err := jm.StdoutStream(userName1, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, "this is standard output", string(<-stream.Stream()))
+}
+
+func Test_JobManager_StdoutStream_NonmatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = job.Stop()
+
+	_, err := jm.StdoutStream("someOtherUser", job.Id().String())
+
+	assert.Error(t, err)
+}
+
+func Test_JobManager_StdoutStream_Superuser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = job.Stop()
+
+	stream, err := jm.StdoutStream(jobmanager.Superuser, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, "this is standard output", string(<-stream.Stream()))
+}
+
+func Test_JobManager_StderrStream_MatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = job.Stop()
+
+	stream, err := jm.StderrStream(userName1, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, "this is standard error", string(<-stream.Stream()))
+}
+
+func Test_JobManager_StderrStream_NonmatchingUser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = job.Stop()
+
+	_, err := jm.StderrStream("someOtherUser", job.Id().String())
+
+	assert.Error(t, err)
+}
+
+func Test_JobManager_StderrStream_Superuser(t *testing.T) {
+	const userName1 = "user1"
+	const jobName = "user1-job"
+	const programPath = "/bin/true"
+
+	jm := jobmanager.NewManagerDetailed(jobmanagertest.NewMockJob, nil)
+
+	job, _ := jm.Start(userName1, jobName, programPath, nil)
+	_ = job.Stop()
+
+	stream, err := jm.StderrStream(jobmanager.Superuser, job.Id().String())
+
+	assert.Nil(t, err)
+	assert.Equal(t, "this is standard error", string(<-stream.Stream()))
+}


### PR DESCRIPTION
This change adds the Manager implementation.  It extracts an
interface from the job type to enable mocking.  It adds a MockJob
realization of the new Job interface.  It tests the newly-added
JobManager using the mock.