### PR TITLE
Mkfile prgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,50 @@
 SHELL = bash
 MKDIR = mkdir
+BUILDDIR = build
+EXECUTABLES  = $(BUILDDIR)/test-concurrentreads
+EXECUTABLES += $(BUILDDIR)/test-blkiolimit
+EXECUTABLES += $(BUILDDIR)/test-memorylimit
+EXECUTABLES += $(BUILDDIR)/test-cpulimit
+EXECUTABLES += $(BUILDDIR)/test-pidnamespace
+EXECUTABLES += $(BUILDDIR)/test-networknamespace
 
 GOTEST := go test
 ifneq ($(shell which gotestsum),)
 	GOTEST := gotestsum --
 endif
 
-builddir:
-	@mkdir -p build
+all: $(BUILDDIR) $(BUILDDIR)/cgexec $(EXECUTABLES)
 
-cgexec: CGO_ENABLED=0
-cgexec: GOOS=linux
-cgexec: GOARCH=amd64
-cgexec: BUILDFLAGS=-buildmode pie -tags 'osusergo netgo static_build'
-cgexec: dep builddir cmd/cgexec/cgexec.go
-	go build -o build/cgexec cmd/cgexec/cgexec.go
-.PHONY: cgexec
+$(BUILDDIR):
+	mkdir -p $(BUILDDIR)
+
+$(BUILDDIR)/cgexec: CGO_ENABLED=0
+$(BUILDDIR)/cgexec: GOOS=linux
+$(BUILDDIR)/cgexec: GOARCH=amd64
+$(BUILDDIR)/cgexec: BUILDFLAGS=-buildmode pie -tags 'osusergo netgo static_build'
+$(BUILDDIR)/cgexec: dep $(BUILDDIR) cmd/cgexec/cgexec.go
+	go build -race -o $(BUILDDIR)/cgexec cmd/cgexec/cgexec.go
+
+$(BUILDDIR)/test-concurrentreads: dep $(BUILDDIR) test/job/concurrentreads/concurrentreads.go
+	go build -race -o $(BUILDDIR)/test-concurrentreads test/job/concurrentreads/concurrentreads.go
+
+$(BUILDDIR)/test-blkiolimit: dep $(BUILDDIR) test/job/blkiolimit/blkiolimit.go
+	go build -race -o $(BUILDDIR)/test-blkiolimit test/job/blkiolimit/blkiolimit.go
+
+$(BUILDDIR)/test-memorylimit: dep $(BUILDDIR) test/job/memorylimit/memorylimit.go
+	go build -race -o $(BUILDDIR)/test-memorylimit test/job/memorylimit/memorylimit.go
+
+$(BUILDDIR)/test-cpulimit: dep $(BUILDDIR) test/job/cpulimit/cpulimit.go
+	go build -race -o $(BUILDDIR)/test-cpulimit test/job/cpulimit/cpulimit.go
+
+$(BUILDDIR)/test-pidnamespace: dep $(BUILDDIR) test/job/pidnamespace/pidnamespace.go
+	go build -race -o $(BUILDDIR)/test-pidnamespace test/job/pidnamespace/pidnamespace.go
+
+$(BUILDDIR)/test-networknamespace: dep $(BUILDDIR) test/job/networknamespace/networknamespace.go
+	go build -race -o $(BUILDDIR)/test-networknamespace test/job/networknamespace/networknamespace.go
 
 clean:
-	$(RM) -r build
+	$(RM) -r $(BUILDDIR)
 .PHONY: clean
 
 test: vet
@@ -26,9 +52,10 @@ test: vet
 .PHONY: test
 
 vet: dep
-	@go vet ./...
+	@go vet -race ./...
 .PHONY: vet
 
 dep:
 	@go mod download
 .PHONY: dep
+#test/job/networknamespace/networknamespace.go

--- a/README.md
+++ b/README.md
@@ -40,21 +40,21 @@ for unit testing.  I currently run this via `sudo`, but I plan to look into
 setting up a cgroup configuration that would enable these to work as a
 non-privileged user.
 
-* test/job/blkiolimit/blkiolimit.go
+* test/job/blkiolimit/blkiolimit.go (build/test-blkiolimit)
   A test to illustrate that the blockio cgroup limit controls the job output.
   This could be extended to also check input limits.
 
-* test/job/memorylimit/memorylimit.go
+* test/job/memorylimit/memorylimit.go (build/test-memorylimit)
   A test to illustrate that the memory cgroup limit controls the job output.
 
-* test/job/cpulimit/cpulimit.go
+* test/job/cpulimit/cpulimit.go (build/test-cpulimit)
   A test to illustrate that the cpu cgroup limit controls the job output.
 
-* test/job/pidnamespace/pidnamespace.go
+* test/job/pidnamespace/pidnamespace.go (build/test-pidnamespace)
   A test to illustrate that the job is running in its own pid namespace
 
-* test/job/networknamespace/networknamespace.go
+* test/job/networknamespace/networknamespace.go (build/test-networknamespace)
   A test to illustrate that the job is running in its own network namespace
 
-* test/job/concurrentreads/concurrentreads.go
+* test/job/concurrentreads/concurrentreads.go (build/test-concurrentreads)
   A test to illustrate that a single job can have multiple concurrent readers

--- a/test/job/concurrentreads/concurrentreads.go
+++ b/test/job/concurrentreads/concurrentreads.go
@@ -8,10 +8,11 @@ import (
 )
 
 func runTest() {
+
 	job := jobmanager.NewJob("theOwner", "my-test", nil,
 		"/bin/bash",
 		"-c",
-		"for ((i = 0; i < 10000; ++i)); do echo $RANDOM; done",
+		"for ((i = 0; i < 100; ++i)); do for((j = 0; j < 1000; ++j)); do echo $RANDOM; done; sleep 0.25; done",
 	)
 
 	if err := job.Start(); err != nil {
@@ -22,14 +23,17 @@ func runTest() {
 	wg.Add(100)
 
 	for i := 0; i < 100; i++ {
-		go func() {
+		go func(threadNum int) {
 			count := 0
 			for output := range job.StdoutStream().Stream() {
 				count += len(output)
+				if threadNum == 0 {
+					fmt.Print(string(output))
+				}
 			}
-			fmt.Printf("%d\n", count)
+			fmt.Printf("%d: %d\n", threadNum, count)
 			wg.Done()
-		}()
+		}(i)
 	}
 
 	wg.Wait()
@@ -38,6 +42,7 @@ func runTest() {
 // The job generates 10000 random numbers and prints them to standard output
 // The program starts 100 goroutines to consume that output.  Each goroutine
 // counts and prints the number of bytes that it receives.
+
 func main() {
 	runTest()
 }


### PR DESCRIPTION
This change updates the Makefile so that the default `all` target builds
test binaries.  It also tweaks the concurrentreads test to introduce
some periodic delays to better exercise the blocking behavior.